### PR TITLE
Fix model mapping bug where ChapterEntity.id is erroneously set.

### DIFF
--- a/src/main/java/de/unistuttgart/iste/meitrex/course_service/config/ModelMapperConfiguration.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/course_service/config/ModelMapperConfiguration.java
@@ -1,6 +1,8 @@
 package de.unistuttgart.iste.meitrex.course_service.config;
 
 import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
+import org.modelmapper.spi.MatchingStrategy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,6 +14,9 @@ public class ModelMapperConfiguration {
 
     @Bean
     public ModelMapper modelMapper() {
-        return new ModelMapper();
+        ModelMapper mapper = new ModelMapper();
+        mapper.getConfiguration().setMatchingStrategy(MatchingStrategies.STRICT);
+
+        return mapper;
     }
 }

--- a/src/main/java/de/unistuttgart/iste/meitrex/course_service/persistence/mapper/ChapterMapper.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/course_service/persistence/mapper/ChapterMapper.java
@@ -20,7 +20,6 @@ public class ChapterMapper {
 
     public ChapterEntity dtoToEntity(CreateChapterInput chapterInput) {
         ChapterEntity entity = modelMapper.map(chapterInput, ChapterEntity.class);
-        entity.setCourseId(chapterInput.getCourseId());
         return entity;
     }
 

--- a/src/main/java/de/unistuttgart/iste/meitrex/course_service/service/ChapterService.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/course_service/service/ChapterService.java
@@ -12,6 +12,7 @@ import de.unistuttgart.iste.meitrex.course_service.persistence.validation.Chapte
 import de.unistuttgart.iste.meitrex.generated.dto.*;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.lang.Nullable;
@@ -27,6 +28,7 @@ import static org.springframework.data.jpa.domain.Specification.where;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ChapterService {
 
     private final ChapterMapper chapterMapper;


### PR DESCRIPTION
Previously, we used model mappers "standard" matching strategy. This meant that when mapping the CreateChapterInputDto to ChapterEntity, the ID property was erroneously set to the value of the courseId property.

With a recent update to hibernate, this resulted in failed database insertions, because hibernate expects the ID of an entity which has not yet been added to the database to be unset.

This PR sets the matching strategy of model mapper to "strict", which means model mapper will only match properties whose name matches EXACTLY.