### PR TITLE
Add graphql interface  _internal_userIdsByCourseId

### DIFF
--- a/src/main/java/de/unistuttgart/iste/meitrex/course_service/controller/MembershipController.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/course_service/controller/MembershipController.java
@@ -21,6 +21,11 @@ public class MembershipController {
 
     private final MembershipService membershipService;
 
+    @QueryMapping(name = "_internal_userIdsByCourseId")
+    public List<UUID> userIdsByCourseId(@Argument UUID courseId) {
+        return membershipService.getUserIdsOfCourse(courseId);
+    }
+
     @QueryMapping(name = "_internal_noauth_courseMembershipsByUserId")
     public List<CourseMembership> courseMembershipsByUserIds(@Argument final UUID userId,
                                                              @Argument final Boolean availabilityFilter) {

--- a/src/main/java/de/unistuttgart/iste/meitrex/course_service/persistence/repository/CourseMembershipRepository.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/course_service/persistence/repository/CourseMembershipRepository.java
@@ -3,6 +3,8 @@ package de.unistuttgart.iste.meitrex.course_service.persistence.repository;
 import de.unistuttgart.iste.meitrex.course_service.persistence.entity.CourseMembershipEntity;
 import de.unistuttgart.iste.meitrex.course_service.persistence.entity.CourseMembershipPk;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -29,4 +31,7 @@ public interface CourseMembershipRepository extends JpaRepository<CourseMembersh
      * @return List of CourseMembershipEntities for the course with the given id.
      */
     List<CourseMembershipEntity> findCourseMembershipEntitiesByCourseId(UUID courseId);
+
+    @Query("SELECT c.userId FROM CourseMembership c WHERE c.courseId = :courseId")
+    List<UUID> findUserIdsByCourseId(@Param("courseId") UUID courseId);
 }

--- a/src/main/java/de/unistuttgart/iste/meitrex/course_service/service/MembershipService.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/course_service/service/MembershipService.java
@@ -116,6 +116,16 @@ public class MembershipService {
                 .toList();
     }
 
+    /**
+     * Returns all users of a course
+     *
+     * @param courseId ID of the course
+     * @return List of UserIds
+     */
+    public List<UUID> getUserIdsOfCourse(final UUID courseId) {
+            return courseMembershipRepository.findUserIdsByCourseId(courseId);
+        }
+
     private Predicate<? super CourseMembership> byAvailability(final Boolean availableCoursesFilter) {
         return membership -> {
             if (availableCoursesFilter == null) {

--- a/src/main/resources/graphql/service/query.graphqls
+++ b/src/main/resources/graphql/service/query.graphqls
@@ -23,6 +23,12 @@ type Query {
     coursesByIds(ids: [UUID!]!): [Course!]!
 
     """
+    Returns the users who subscribed the given course id.
+    """
+
+    _internal_userIdsByCourseId(courseId: UUID!): [UUID!]!
+
+    """
     Returns the chapters with the given ids.
     ⚠️ This query is only accessible internally in the system and allows the caller to retrieve courseMemberships for
     any user and should not be called without any validation of the caller's permissions. ⚠️


### PR DESCRIPTION
## Description of changes
Add graphql interface  _internal_userIdsByCourseId for notification service. Other service can get UserIdsByCourseIds through Graphql.

  
## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [ ] automated unit test
- [ ] automated integration test
- [ ] manual, exploratory test

In case of manual test, please document the test well including a set of user instructions and prerequisites. Each including an action, it's result, and where appropriate a screenshot.
    
## Checklist before requesting a review

- [ ] My code is easy to understand
- [ ] My code follows the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] My code fulfills all acceptance criteria
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/MEITREX/wiki/tree/main/adr)
- [ ] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
